### PR TITLE
Tweak for NixOS compatibility.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM python:3.9
 
 ARG DOCKER_UID
 ARG DOCKER_GID
-RUN groupadd -r docker-user -g $DOCKER_GID && useradd -r -u $DOCKER_UID -g $DOCKER_GID -m -s /bin/false -g docker-user docker-user
+RUN groupadd -f -r docker-user -g $DOCKER_GID && useradd -r -u $DOCKER_UID -g $DOCKER_GID -m -s /bin/false -g docker-user docker-user
 
 RUN apt update && apt install -y less nano jq git zstd
 

--- a/start.sh
+++ b/start.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 # Path to repo/project root dir (independent of pwd)


### PR DESCRIPTION
bash is not POSIX, but /usr/bin/env is, and NixOS can find bash this way. Please double-check that it also works for you.

Also, on at least NixOS and Debian, the default GIDs overlap with the container's GIDs from Ubuntu. Here, the `-f` flag avoids a spurious failure. I was otherwise able to get `./start.sh` to work perfectly.